### PR TITLE
Add SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# SPM build artifacts
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "TikTokBusinessSDK",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "TikTokBusinessSDK",
+            targets: ["TikTokBusinessSDK"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "TikTokBusinessSDK",
+            dependencies: [],
+            path: "TikTokBusinessSDK",
+            publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("./"),
+                .headerSearchPath("AppEvents"),
+                .headerSearchPath("TiktokSKAdNetwork"),
+                .headerSearchPath("TikTokAdditions"),
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+            ]
+        ),
+        .testTarget(
+            name: "TikTokBusinessSDKTests",
+            dependencies: ["TikTokBusinessSDK"],
+            path: "TikTokBusinessSDKTests"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/TikTokBusinessSDK.podspec
+++ b/TikTokBusinessSDK.podspec
@@ -23,7 +23,10 @@ The TikTok Business SDK is the easiest way to log events (e.g. app install, purc
   s.ios.deployment_target = '9.0'
 
   s.source_files = 'TikTokBusinessSDK/**/*'
-  s.exclude_files = "TikTokBusinessSDK/*.plist"
+  s.exclude_files = [
+      "TikTokBusinessSDK/*.plist",
+      "TikTokBusinessSDK/Public/TikTokBusinessSDK/*.h"
+  ]
   s.swift_version = '5.0'
 
 end

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEvent.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEvent.h
@@ -1,0 +1,1 @@
+../../AppEvents/TikTokAppEvent.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventQueue.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventQueue.h
@@ -1,0 +1,1 @@
+../../AppEvents/TikTokAppEventQueue.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventStore.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventStore.h
@@ -1,0 +1,1 @@
+../../AppEvents/TikTokAppEventStore.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventUtility.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokAppEventUtility.h
@@ -1,0 +1,1 @@
+../../AppEvents/TikTokAppEventUtility.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokBusiness.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokBusiness.h
@@ -1,0 +1,1 @@
+../../TikTokBusiness.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokBusinessSDK.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokBusinessSDK.h
@@ -1,0 +1,1 @@
+../../TikTokBusinessSDK.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokConfig.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokConfig.h
@@ -1,0 +1,1 @@
+../../TikTokConfig.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokDeviceInfo.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokDeviceInfo.h
@@ -1,0 +1,1 @@
+../../TikTokDeviceInfo.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokErrorHandler.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokErrorHandler.h
@@ -1,0 +1,1 @@
+../../TikTokErrorHandler.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokLogger.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokLogger.h
@@ -1,0 +1,1 @@
+../../TikTokLogger.h

--- a/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokRequestHandler.h
+++ b/TikTokBusinessSDK/Public/TikTokBusinessSDK/TikTokRequestHandler.h
@@ -1,0 +1,1 @@
+../../TikTokRequestHandler.h

--- a/TikTokBusinessSDKTests/AppEvents/TikTokAppEventQueueTests.m
+++ b/TikTokBusinessSDKTests/AppEvents/TikTokAppEventQueueTests.m
@@ -30,7 +30,7 @@
 
 - (void)setUp {
     [super setUp];
-    TikTokConfig *config = [[TikTokConfig alloc] initWithAccessToken:@"ACCESS_TOKEN" appId: @"123" tiktokAppId: @"ABC"];
+    TikTokConfig *config = [[TikTokConfig alloc] initWithAppId: @"ABC" tiktokAppId: @123];
     [TikTokBusiness initializeSdk:config];
     TikTokBusiness *tiktokBusiness = [TikTokBusiness getInstance];
     self.tiktokBusiness = OCMPartialMock(tiktokBusiness);


### PR DESCRIPTION
Outline
---
#### This PR ads basic support for SDK integration via Swift Package Manager.

Disclaimer
---
- I did not want to change the project structure, so I've just symlinked the public headers in `TikTokBusinessSDK/Public/TikTokBusinessSDK`. Obviously it would be better to restructure the project, but this is something for the project maintainers to decide.
- The podspec has been changed to exclude the symlinks but this is **untested**
- I just tested basic integration in our project. Seems to be working ok.

Tests
---

Tests won't work via `swift test` because some of the dependencies (eg. `UIKit`) are not available on all platforms. So I'm not sure how much sense it makes to add the testTarget.

However, tests can be run with `/usr/bin/arch -arch x86_64 xcodebuild test -scheme TikTokBusinessSDKTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13 Pro'`